### PR TITLE
libkmod: add fallback MODULE_INIT_COMPRESSED_FILE define

### DIFF
--- a/libkmod/libkmod-file.c
+++ b/libkmod/libkmod-file.c
@@ -498,7 +498,7 @@ error:
 /*
  *  Callers should just check file->memory got updated
  */
-void kmod_file_load_contents(struct kmod_file *file)
+KMOD_EXPORT void kmod_file_load_contents(struct kmod_file *file)
 {
 	if (file->memory)
 		return;
@@ -507,22 +507,22 @@ void kmod_file_load_contents(struct kmod_file *file)
 	file->ops->load(file);
 }
 
-void *kmod_file_get_contents(const struct kmod_file *file)
+KMOD_EXPORT void *kmod_file_get_contents(const struct kmod_file *file)
 {
 	return file->memory;
 }
 
-off_t kmod_file_get_size(const struct kmod_file *file)
+KMOD_EXPORT off_t kmod_file_get_size(const struct kmod_file *file)
 {
 	return file->size;
 }
 
-enum kmod_file_compression_type kmod_file_get_compression(const struct kmod_file *file)
+KMOD_EXPORT enum kmod_file_compression_type kmod_file_get_compression(const struct kmod_file *file)
 {
 	return file->compression;
 }
 
-int kmod_file_get_fd(const struct kmod_file *file)
+KMOD_EXPORT int kmod_file_get_fd(const struct kmod_file *file)
 {
 	return file->fd;
 }

--- a/libkmod/libkmod-index.c
+++ b/libkmod/libkmod-index.c
@@ -247,7 +247,7 @@ static struct index_node_f *index_read(FILE *in, uint32_t offset)
 
 	if (offset & INDEX_NODE_PREFIX) {
 		struct strbuf buf;
-		strbuf_init(&buf);
+		kmod_strbuf_init(&buf);
 		buf_freadchars(&buf, in);
 		prefix = strbuf_steal(&buf);
 	} else
@@ -281,7 +281,7 @@ static struct index_node_f *index_read(FILE *in, uint32_t offset)
 
 		value_count = read_long(in);
 
-		strbuf_init(&buf);
+		kmod_strbuf_init(&buf);
 		while (value_count--) {
 			priority = read_long(in);
 			buf_freadchars(&buf, in);
@@ -401,7 +401,7 @@ void index_dump(struct index_file *in, int fd, const char *prefix)
 	if (root == NULL)
 		return;
 
-	strbuf_init(&buf);
+	kmod_strbuf_init(&buf);
 	strbuf_pushchars(&buf, prefix);
 	index_dump_node(root, &buf, fd);
 	strbuf_release(&buf);
@@ -593,7 +593,7 @@ struct index_value *index_searchwild(struct index_file *in, const char *key)
 	struct strbuf buf;
 	struct index_value *out = NULL;
 
-	strbuf_init(&buf);
+	kmod_strbuf_init(&buf);
 	index_searchwild__node(root, &buf, key, 0, &out);
 	strbuf_release(&buf);
 	return out;
@@ -882,7 +882,7 @@ void index_mm_dump(struct index_mm *idx, int fd, const char *prefix)
 	if (root == NULL)
 		return;
 
-	strbuf_init(&buf);
+	kmod_strbuf_init(&buf);
 	strbuf_pushchars(&buf, prefix);
 	index_mm_dump_node(root, &buf, fd);
 	strbuf_release(&buf);
@@ -1075,7 +1075,7 @@ struct index_value *index_mm_searchwild(struct index_mm *idx, const char *key)
 	struct strbuf buf;
 	struct index_value *out = NULL;
 
-	strbuf_init(&buf);
+	kmod_strbuf_init(&buf);
 	index_mm_searchwild_node(root, &buf, key, 0, &out);
 	strbuf_release(&buf);
 	return out;

--- a/libkmod/libkmod-internal.h
+++ b/libkmod/libkmod-internal.h
@@ -61,12 +61,6 @@ struct kmod_list {
 	void *data;
 };
 
-enum kmod_file_compression_type {
-	KMOD_FILE_COMPRESSION_NONE = 0,
-	KMOD_FILE_COMPRESSION_ZSTD,
-	KMOD_FILE_COMPRESSION_XZ,
-	KMOD_FILE_COMPRESSION_ZLIB,
-};
 
 struct kmod_list *kmod_list_append(struct kmod_list *list, const void *data) _must_check_ __attribute__((nonnull(2)));
 struct kmod_list *kmod_list_prepend(struct kmod_list *list, const void *data) _must_check_ __attribute__((nonnull(2)));
@@ -160,11 +154,6 @@ bool kmod_module_is_builtin(struct kmod_module *mod) __attribute__((nonnull(1)))
 /* libkmod-file.c */
 struct kmod_file *kmod_file_open(const struct kmod_ctx *ctx, const char *filename) _must_check_ __attribute__((nonnull(1,2)));
 struct kmod_elf *kmod_file_get_elf(struct kmod_file *file) __attribute__((nonnull(1)));
-void kmod_file_load_contents(struct kmod_file *file) __attribute__((nonnull(1)));
-void *kmod_file_get_contents(const struct kmod_file *file) _must_check_ __attribute__((nonnull(1)));
-off_t kmod_file_get_size(const struct kmod_file *file) _must_check_ __attribute__((nonnull(1)));
-enum kmod_file_compression_type kmod_file_get_compression(const struct kmod_file *file) _must_check_ __attribute__((nonnull(1)));
-int kmod_file_get_fd(const struct kmod_file *file) _must_check_ __attribute__((nonnull(1)));
 void kmod_file_unref(struct kmod_file *file) __attribute__((nonnull(1)));
 
 /* libkmod-elf.c */

--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -817,6 +817,26 @@ KMOD_EXPORT const char *kmod_module_get_path(const struct kmod_module *mod)
 	return mod->path;
 }
 
+KMOD_EXPORT struct kmod_file *kmod_module_get_file(const struct kmod_module *mod)
+{
+	if (mod == NULL)
+		return NULL;
+
+	if (mod->file == NULL && !kmod_module_is_builtin((struct kmod_module *)mod)) {
+		const char *path = kmod_module_get_path(mod);
+
+		if (path == NULL)
+			return NULL;
+
+		((struct kmod_module *)mod)->file = kmod_file_open(mod->ctx, path);
+	}
+
+	if (mod->file)
+		kmod_file_load_contents(mod->file);
+
+	return mod->file;
+}
+
 
 extern long delete_module(const char *name, unsigned int flags);
 

--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -2396,6 +2396,12 @@ KMOD_EXPORT int kmod_module_get_info(const struct kmod_module *mod, struct kmod_
 			goto list_error;
 		count++;
 
+		n = kmod_module_info_append(list, "sig_algo", strlen("sig_algo"),
+				sig_info.algo, strlen(sig_info.algo));
+		if (n == NULL)
+			goto list_error;
+		count++;
+
 		n = kmod_module_info_append(list,
 				"sig_hashalgo", strlen("sig_hashalgo"),
 				sig_info.hash_algo, strlen(sig_info.hash_algo));
@@ -2403,10 +2409,6 @@ KMOD_EXPORT int kmod_module_get_info(const struct kmod_module *mod, struct kmod_
 			goto list_error;
 		count++;
 
-		/*
-		 * Omit sig_info.algo for now, as these
-		 * are currently constant.
-		 */
 		n = kmod_module_info_append(list, "signature", strlen("signature"),
 						sig_info.sig,
 						sig_info.sig_len);

--- a/libkmod/libkmod-signature.c
+++ b/libkmod/libkmod-signature.c
@@ -141,6 +141,20 @@ static void pkcs7_free(void *s)
 	si->private = NULL;
 }
 
+static const char *obj_to_sig_algo(const ASN1_OBJECT *o)
+{
+	int nid = OBJ_obj2nid(o);
+
+	switch (nid) {
+	case NID_sha256WithRSAEncryption:
+		return "sha256WithRSAEncryption";
+	case NID_SM2_with_SM3:
+		return "SM2-with-SM3";
+	default:
+		return "unknown";
+	}
+}
+
 static int obj_to_hash_algo(const ASN1_OBJECT *o)
 {
 	int nid;
@@ -276,8 +290,10 @@ static bool fill_pkcs7(const char *mem, off_t size,
 		sig_info->signer_len = strlen(issuer_str);
 	}
 
-	X509_ALGOR_get0(&o, NULL, NULL, dig_alg);
+	X509_ALGOR_get0(&o, NULL, NULL, sig_alg);
+	sig_info->algo = obj_to_sig_algo(o);
 
+	X509_ALGOR_get0(&o, NULL, NULL, dig_alg);
 	hash_algo = obj_to_hash_algo(o);
 	if (hash_algo < 0)
 		goto err3;

--- a/libkmod/libkmod.h
+++ b/libkmod/libkmod.h
@@ -206,6 +206,23 @@ int kmod_module_apply_filter(const struct kmod_ctx *ctx,
 
 
 
+enum kmod_file_compression_type {
+	KMOD_FILE_COMPRESSION_NONE = 0,
+	KMOD_FILE_COMPRESSION_ZSTD,
+	KMOD_FILE_COMPRESSION_XZ,
+	KMOD_FILE_COMPRESSION_ZLIB,
+};
+
+struct kmod_file;
+struct kmod_file *kmod_module_get_file(const struct kmod_module *mod);
+void kmod_file_load_contents(struct kmod_file *file);
+void *kmod_file_get_contents(const struct kmod_file *file);
+off_t kmod_file_get_size(const struct kmod_file *file);
+enum kmod_file_compression_type kmod_file_get_compression(const struct kmod_file *file);
+int kmod_file_get_fd(const struct kmod_file *file);
+
+
+
 /*
  * Information regarding "live information" from module's state, as returned
  * by kernel

--- a/libkmod/libkmod.h
+++ b/libkmod/libkmod.h
@@ -238,6 +238,7 @@ long kmod_module_get_size(const struct kmod_module *mod);
 int kmod_module_get_info(const struct kmod_module *mod, struct kmod_list **list);
 const char *kmod_module_info_get_key(const struct kmod_list *entry);
 const char *kmod_module_info_get_value(const struct kmod_list *entry);
+const char *kmod_module_info_get_value_n(const struct kmod_list *entry, size_t *valuelen);
 void kmod_module_info_free_list(struct kmod_list *list);
 
 int kmod_module_get_versions(const struct kmod_module *mod, struct kmod_list **list);

--- a/libkmod/libkmod.sym
+++ b/libkmod/libkmod.sym
@@ -92,3 +92,8 @@ LIBKMOD_22 {
 global:
 	kmod_get_dirname;
 } LIBKMOD_6;
+
+LIBKMOD_31 {
+global:
+	kmod_module_info_get_value_n;
+} LIBKMOD_22;

--- a/shared/missing.h
+++ b/shared/missing.h
@@ -15,6 +15,10 @@
 # define MODULE_INIT_IGNORE_VERMAGIC 2
 #endif
 
+#ifndef MODULE_INIT_COMPRESSED_FILE
+# define MODULE_INIT_COMPRESSED_FILE 4
+#endif
+
 #ifndef __NR_finit_module
 # define __NR_finit_module -1
 #endif

--- a/shared/strbuf.c
+++ b/shared/strbuf.c
@@ -49,7 +49,7 @@ static bool buf_grow(struct strbuf *buf, size_t newsize)
 	return true;
 }
 
-void strbuf_init(struct strbuf *buf)
+void kmod_strbuf_init(struct strbuf *buf)
 {
 	buf->bytes = NULL;
 	buf->size = 0;

--- a/shared/strbuf.h
+++ b/shared/strbuf.h
@@ -11,7 +11,7 @@ struct strbuf {
 	unsigned used;
 };
 
-void strbuf_init(struct strbuf *buf);
+void kmod_strbuf_init(struct strbuf *buf);
 void strbuf_release(struct strbuf *buf);
 void strbuf_clear(struct strbuf *buf);
 

--- a/testsuite/test-strbuf.c
+++ b/testsuite/test-strbuf.c
@@ -36,7 +36,7 @@ static int test_strbuf_pushchar(const struct test *t)
 	char *result1, *result2;
 	const char *c;
 
-	strbuf_init(&buf);
+	kmod_strbuf_init(&buf);
 
 	for (c = TEXT; *c != '\0'; c++)
 		strbuf_pushchar(&buf, *c);
@@ -64,7 +64,7 @@ static int test_strbuf_pushchars(const struct test *t)
 	const char *c;
 	int lastwordlen = 0;
 
-	strbuf_init(&buf);
+	kmod_strbuf_init(&buf);
 	str = strdup(TEXT);
 	for (c = strtok_r(str, " ", &saveptr); c != NULL;
 	     c = strtok_r(NULL, " ", &saveptr)) {

--- a/tools/modinfo.c
+++ b/tools/modinfo.c
@@ -168,6 +168,33 @@ end:
 	return err;
 }
 
+static char *hex_to_str(const char *hex, size_t len)
+{
+	char *str;
+	int i;
+	int j;
+	const size_t line_limit = 20;
+	size_t str_len;
+
+	str_len = len * 3; /* XX: or XX\0 */
+	str_len += ((str_len + line_limit - 1) / line_limit - 1) * 3; /* \n\t\t */
+
+	str = malloc(str_len);
+	if (str == NULL)
+		return NULL;
+
+	for (i = 0, j = 0; i < (int)len; i++) {
+		j += sprintf(str + j, "%02X", (unsigned char)hex[i]);
+		if (i < (int)len - 1) {
+			str[j++] = ':';
+
+			if ((i + 1) % line_limit == 0)
+				j += sprintf(str + j, "\n\t\t");
+		}
+	}
+	return str;
+}
+
 static int modinfo_do(struct kmod_module *mod)
 {
 	struct kmod_list *l, *list = NULL;
@@ -214,32 +241,35 @@ static int modinfo_do(struct kmod_module *mod)
 	}
 
 	kmod_list_foreach(l, list) {
+        size_t valuelen;
 		const char *key = kmod_module_info_get_key(l);
-		const char *value = kmod_module_info_get_value(l);
+		const char *value = kmod_module_info_get_value_n(l, &valuelen);
+		char *hex = NULL;
 		int keylen;
+
+		if ((streq(key, "sig_key") || streq(key, "signature")) && valuelen > 0) {
+			hex = hex_to_str(value, valuelen);
+			value = hex;
+		}
 
 		if (field != NULL) {
 			if (!streq(field, key))
 				continue;
 			/* filtered output contains no key, just value */
 			printf("%s%c", value, separator);
-			continue;
-		}
-
-		if (streq(key, "parm") || streq(key, "parmtype")) {
+		} else if (streq(key, "parm") || streq(key, "parmtype")) {
 			err = process_parm(key, value, &params);
 			if (err < 0)
 				goto end;
-			continue;
-		}
-
-		if (separator == '\0') {
+		} else if (separator == '\0') {
 			printf("%s=%s%c", key, value, separator);
-			continue;
+		} else {
+			keylen = strlen(key);
+			printf("%s:%-*s%s%c", key, 15 - keylen, "", value, separator);
 		}
 
-		keylen = strlen(key);
-		printf("%s:%-*s%s%c", key, 15 - keylen, "", value, separator);
+		if (hex)
+			free(hex);
 	}
 
 	if (field != NULL)


### PR DESCRIPTION
The symbol was somewhat recently introduced by the kernel and not all distributions may be have available.

The number is part of the ABI, so we can add a local fallback define.

Closes: https://github.com/kmod-project/kmod/issues/29